### PR TITLE
Fix uloop_run_timeout when no timers are running

### DIFF
--- a/uloop.c
+++ b/uloop.c
@@ -548,8 +548,11 @@ int uloop_run_timeout(int timeout)
 		uloop_gettime(&tv);
 
 		next_time = uloop_get_next_timeout(&tv);
-		if (timeout >= 0 && timeout < next_time)
-			next_time = timeout;
+                if (((timeout >= 0) && (timeout < next_time)) ||
+                    ((next_time == -1) && (timeout != -1))
+		   ) {
+                        next_time = timeout;
+		}
 		uloop_run_events(next_time);
 	}
 


### PR DESCRIPTION
If uloop_run_timeout is called and no existing timers are running next_time is -1 and the timeout
value is ignored.