### PR TITLE
Clean up callbacks to avoid double deletes

### DIFF
--- a/lua/uloop.c
+++ b/lua/uloop.c
@@ -29,6 +29,30 @@
 #include "../uloop.h"
 #include "../list.h"
 
+/*** A few notes about the callbacks.
+ * When the raw uloop callback is called, the lua `state` is _always_ the main
+ * coroutine of lua, and all callback execute on it.  The _cb functions _must_
+ * start and end with the stack unmodified, or else very bad data corruption
+ * will happen in lua.  In other words, _cb must leave the stack exactly as it
+ * found it, if there were 0 items, it must leave 0 items, if there were 10 items
+ * it must leave those exact same 10 items.
+ *
+ * When a lua callback function is passed in, it's wraped in a C closure,
+ * using the Lua callback as the upvalue. We need a unique object to
+ * create a reference from, and we can't assume the function passed in is
+ * unique.  Why make that requirement on the developer? For example
+ * `uloop.timer(uloop.cancel)` should be a valid call, and it should also not
+ * conflict with any other functions that uloop creates, or anyone else uses
+ * for a reference.  So create a new lua object, in this case a new closure.
+ * It was a single up value, the callback is should call.  This then guarantees
+ * that the call to luaL_ref returns a unique value.
+ */
+
+#define MODNAME		"uloop"
+#define TIMER_METANAME		MODNAME ".timer"
+#define PROCESS_METANAME	MODNAME ".process"
+#define FD_METANAME			MODNAME ".fd"
+
 struct lua_uloop_fd {
 	struct uloop_fd fd;
 	int r;
@@ -52,21 +76,28 @@ static __attribute__((unused)) void stackDump (lua_State *L) {
 	int top = lua_gettop(L);  /* depth of the stack */
 	for (i = 1; i <= top; i++) {  /* repeat for each level */
 		int t = lua_type(L, i);
-		printf("%d: ", i);
 		switch (t) {
 			case LUA_TSTRING: {  /* strings */
+								  printf("%d: ", i);
 								  printf("'%s'", lua_tostring(L, i));
 								  break;
 							  }
 			case LUA_TBOOLEAN: {  /* Booleans */
+								  printf("%d: ", i);
 								   printf(lua_toboolean(L, i) ? "true" : "false");
 								   break; }
 			case LUA_TNUMBER: {  /* numbers */
+								  printf("%d: ", i);
 								  printf("%g", lua_tonumber(L, i));
 								  break;
 							  }
 			default: {  /* other values */
-						 printf("%s", lua_typename(L, t));
+						 lua_getglobal(L, "tostring");
+						 lua_pushvalue(L, i);
+						 lua_call(L, 1, 1);
+						 const char *tostring = lua_tostring(L, -1);
+						 lua_pop(L, 1);
+						 printf("%d: %s", i, tostring);
 						 break; }
 		}
 		printf(", ");  /* put a separator */
@@ -74,63 +105,40 @@ static __attribute__((unused)) void stackDump (lua_State *L) {
 	printf("\n");  /* end the listing */
 }
 
-static void *
-ul_create_userdata(lua_State *L, size_t size, const luaL_Reg *reg, lua_CFunction gc)
-{
-
-	void *ret = lua_newuserdata(L, size); // S: nud
-
-	memset(ret, 0, size);
-	lua_createtable(L, 0, 2);   // create a new table, with hint 2 other elements, S: nud, table
-	lua_pushvalue(L, -1);       // duplicate it, now S: nud, table, table
-	lua_setfield(L, -2, "__index"); // set t[__index] = t.  S: nud, table
-	lua_pushcfunction(L, gc);   // nud, table, gc
-	lua_setfield(L, -2, "__gc"); // add t[__gc] = gc to t, S: nud, table
-	lua_pushvalue(L, -1);      // nud, table, table
-	lua_setmetatable(L, -3);   // set on metatable for nud, s: nud, table
-	lua_pushvalue(L, -2);      // copy nud, s: nud, table, nud
-	luaL_setfuncs(L, reg, 1);   // registers reg, with 1 up func. s: nud, table
-	lua_pushvalue(L, -2);      // duplicate nud, s: nud, table, nud
-
-	return ret;
-}
-
 static void ul_timer_cb(struct uloop_timeout *t)
 {
 	struct lua_uloop_timeout *tout = container_of(t, struct lua_uloop_timeout, t);
 
-	lua_getglobal(state, "__uloop_cb");
-	int type = lua_rawgeti(state, -1, tout->r);
-	lua_remove(state, -2);
+	lua_rawgeti(state, LUA_REGISTRYINDEX, tout->r);
 
-	if (type == LUA_TFUNCTION) {
-		lua_call(state, 0, 0);
-	} else {
-		printf("In timer callback, asked for callback, didn't get a function\n");
-		stackDump(state);
-	}
+	lua_call(state, 0, 0);
+}
 
+/*
+ * Stored with the upvalues:
+ * 1. lua callback
+ * And called with the no arguments
+ */
+static int ul_timer_closure(lua_State *L)
+{
+	lua_pushvalue(L, lua_upvalueindex(1));
+	lua_call(state, 0, 0);
+	return 0;
 }
 
 static int ul_timer_set(lua_State *L)
 {
-	struct lua_uloop_timeout *tout;
+	struct lua_uloop_timeout *tout = luaL_checkudata(L, 1, TIMER_METANAME);
 	lua_Integer set;
 	int isint;
 
-	if (!lua_isnumber(L, -1)) {
-		lua_pushstring(L, "invalid arg list");
-		lua_error(L);
-
-		return 0;
-	}
+	luaL_checkinteger(L, -1);
 
 	set = lua_tointegerx(L, -1, &isint);
 	if (!isint) {
 		lua_Number n = lua_tonumber(L, -1);
 		set = n;
 	}
-	tout = lua_touserdata(L, 1);
 	uloop_timeout_set(&tout->t, set);
 
 	return 1;
@@ -138,7 +146,7 @@ static int ul_timer_set(lua_State *L)
 
 static int ul_timer_remaining(lua_State *L)
 {
-	struct lua_uloop_timeout *tout;
+	struct lua_uloop_timeout *tout = luaL_checkudata(L, 1, TIMER_METANAME);
 
 	tout = lua_touserdata(L, 1);
 	lua_pushnumber(L, uloop_timeout_remaining(&tout->t));
@@ -147,27 +155,20 @@ static int ul_timer_remaining(lua_State *L)
 
 static int ul_timer_cancel(lua_State *L)
 {
-	struct lua_uloop_timeout *tout = lua_touserdata(L, 1);
+	struct lua_uloop_timeout *tout = luaL_checkudata(L, 1, TIMER_METANAME);
 
 	uloop_timeout_cancel(&tout->t);
 
 	return 0;
 }
 
-static int ul_timer_free(lua_State *L)
+static int ul_timer__gc(lua_State *L)
 {
-	struct lua_uloop_timeout *tout = lua_touserdata(L, 1);
+	struct lua_uloop_timeout *tout = luaL_checkudata(L, 1, TIMER_METANAME);
 
 	uloop_timeout_cancel(&tout->t);
 
-	/* obj.__index.__gc = nil , make sure executing only once*/
-	lua_getfield(L, -1, "__index");
-	lua_pushstring(L, "__gc");
-	lua_pushnil(L);
-	lua_settable(L, -3);
-
-	lua_getglobal(state, "__uloop_cb");
-	luaL_unref(state, -1, tout->r);
+	luaL_unref(state, LUA_REGISTRYINDEX, tout->r);
 
 	return 1;
 }
@@ -176,36 +177,41 @@ static const luaL_Reg timer_m[] = {
 	{ "set", ul_timer_set },
 	{ "remaining", ul_timer_remaining },
 	{ "cancel", ul_timer_cancel },
+	{ "__gc", ul_timer__gc },
 	{ NULL, NULL }
 };
 
+/*** Create a new timer.
+ * tparam[opt] integer Number of milliseconds to set the timer for
+ * tparam func Callback to call when the timer expired
+ * treturn uloop.timer A new timer object
+ */
 static int ul_timer(lua_State *L)
 {
 	struct lua_uloop_timeout *tout;
 	lua_Integer set = 0;
+	int is_set;
 	int ref;
 
-	if (lua_isnumber(L, -1)) {
-		set = lua_tointeger(L, -1);
+	luaL_checktype(L, 1, LUA_TFUNCTION);
+
+	set = lua_tointegerx(L, -1, &is_set);
+	if (is_set) {
 		lua_pop(L, 1);
 	}
 
-	if (!lua_isfunction(L, -1)) {
-		lua_pushstring(L, "invalid arg list");
-		lua_error(L);
+	lua_pushcclosure(L, ul_timer_closure, 1);
 
-		return 0;
-	}
+	ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
-	lua_getglobal(L, "__uloop_cb");
-	lua_pushvalue(L, -2);
-	ref = luaL_ref(L, -2);
-
-	tout = ul_create_userdata(L, sizeof(*tout), timer_m, ul_timer_free);
-	tout->r = ref;
+	tout = lua_newuserdata(L, sizeof(struct lua_uloop_timeout));
+	luaL_setmetatable(L, TIMER_METANAME);
+	memset(tout, 0, sizeof(struct lua_uloop_timeout));
 	tout->t.cb = ul_timer_cb;
 
-	if (set)
+	tout->r = ref;
+
+	if (is_set)
 		uloop_timeout_set(&tout->t, set);
 
 	return 1;
@@ -215,38 +221,48 @@ static void ul_ufd_cb(struct uloop_fd *fd, unsigned int events)
 {
 	struct lua_uloop_fd *ufd = container_of(fd, struct lua_uloop_fd, fd);
 
-	lua_getglobal(state, "__uloop_cb");
-	lua_rawgeti(state, -1, ufd->r);
-	lua_remove(state, -2);
-
-	/* push fd object */
-	lua_getglobal(state, "__uloop_fds");
-	lua_rawgeti(state, -1, ufd->fd_r);
-	lua_remove(state, -2);
+	lua_rawgeti(state, LUA_REGISTRYINDEX, ufd->r);
 
 	/* push events */
 	lua_pushinteger(state, events);
-	lua_call(state, 2, 0);
+	lua_call(state, 1, 0);
 }
 
+/*
+ * Stored with the upvalues:
+ * 1. fd
+ * 2. lua callback
+ * And called with the arguments
+ * 1. Events
+ */
+static int ul_ufd_closure(lua_State *L)
+{
+	lua_pushvalue(L, lua_upvalueindex(2));
+	lua_pushvalue(L, lua_upvalueindex(1));
+	/* stack is now: 1. events 2. lua call back 3. fd */
+	lua_pushvalue(L, 1);
+	/* stack is now: 1. events 2. lua callback 3. fd 4. events */
+
+	/* Should be called with:
+	 * 1. fd
+	 * 2. events
+	 */
+	lua_call(state, 2, 0);
+	return 0;
+}
 
 static int get_sock_fd(lua_State* L, int idx) {
 	int isint = 0;
 	int fd;
-	if(lua_isnumber(L, idx)) {
-		fd = lua_tointegerx(L, idx, &isint);
-		if (!isint) {
-			lua_Number n = lua_tonumber(L, idx);
-			fd = n;
-		}
-	} else {
+	fd = lua_tointegerx(L, idx, &isint);
+	if (!isint) {
 		luaL_checktype(L, idx, LUA_TUSERDATA);
 		lua_getfield(L, idx, "getfd");
 		if(lua_isnil(L, -1))
 			return luaL_error(L, "socket type missing 'getfd' method");
 		lua_pushvalue(L, idx - 1);
 		lua_call(L, 1, 1);
-		fd = lua_tointeger(L, -1);
+		fd = luaL_checkinteger(L, -1);
 		lua_pop(L, 1);
 	}
 	return fd;
@@ -254,112 +270,97 @@ static int get_sock_fd(lua_State* L, int idx) {
 
 static int ul_ufd_delete(lua_State *L)
 {
-	struct lua_uloop_fd *ufd = lua_touserdata(L, 1);
+	struct lua_uloop_fd *ufd = luaL_checkudata(L, 1, FD_METANAME);
 
 	uloop_fd_delete(&ufd->fd);
+	return 0;
+}
 
-	/* obj.__index.__gc = nil , make sure executing only once*/
-	lua_getfield(L, -1, "__index");
-	lua_pushstring(L, "__gc");
-	lua_pushnil(L);
-	lua_settable(L, -3);
+static int ul_ufd__gc(lua_State *L)
+{
+	struct lua_uloop_fd *ufd = luaL_checkudata(L, 1, FD_METANAME);
 
-	lua_getglobal(state, "__uloop_cb");
-	luaL_unref(state, -1, ufd->r);
-	lua_remove(state, -1);
+	uloop_fd_delete(&ufd->fd);
+	luaL_unref(L, LUA_REGISTRYINDEX, ufd->r);
 
-	lua_getglobal(state, "__uloop_fds");
-	luaL_unref(state, -1, ufd->fd_r);
-	lua_remove(state, -1);
-
-	return 1;
+	return 0;
 }
 
 static const luaL_Reg ufd_m[] = {
 	{ "delete", ul_ufd_delete },
+	{ "__gc", ul_ufd__gc },
 	{ NULL, NULL }
 };
 
 /***
- * Add a file descriptor to uloop for call on activity
+ * Add a file descriptor to uloop for call on activity.
  * @function fd_add
- * @tparam int fd File Descriptor to add
- * @tparam function func Callback function
- * @tparam int Option flags or of: uloop.ULOOP_READ, 
- *             uloop.ULOOP_WRITE, uloop.EDGE_TRIGGER, uloop.ULOOP_BLOCKING
+ * @tparam int fd File Descriptor to add.
+ * @tparam function func Callback function.  
+ *                       The callback is called with the following parameters
+ *                       1. fd
+ *                       2. event
+ * @tparam int Option flags.
+ *             Must be a combinatio of: uloop.ULOOP_READ, uloop.ULOOP_WRITE,
+ *             uloop.EDGE_TRIGGER, uloop.ULOOP_BLOCKING
  */
 static int ul_ufd_add(lua_State *L)
 {
 	struct lua_uloop_fd *ufd;
 	int fd = 0;
-	unsigned int flags = 0;
+	lua_Integer flags;
 	int ref;
-	int fd_ref;
-	int isint;
 
-	if (lua_isnumber(L, -1)) {
-		flags = lua_tointegerx(L, -1, &isint);
-		if (!isint) {
-			lua_pushstring(L, "invalid flags provided, must be int");
-			lua_error(L);
-		}
-		lua_pop(L, 1);
-	}
-
-	if (!lua_isfunction(L, -1)) {
-		lua_pushstring(L, "invalid arg list");
-		lua_error(L);
-
-		return 0;
-	}
-
-	fd = get_sock_fd(L, -2);
-
-	lua_getglobal(L, "__uloop_cb");
-	lua_pushvalue(L, -2);
-	ref = luaL_ref(L, -2);
+	fd = get_sock_fd(L, 1);
+	luaL_checktype(L, 2, LUA_TFUNCTION);
+	flags = luaL_checkinteger(L, 3);
 	lua_pop(L, 1);
 
-	lua_getglobal(L, "__uloop_fds");
-	lua_pushvalue(L, -3);
-	fd_ref = luaL_ref(L, -2);
+	/*
+	* Upvalues:
+	* 1. fd
+	* 2. Lua callback
+	*/
+	lua_pushcclosure(L, ul_ufd_closure, 2);
+
+	ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	lua_pop(L, 1);
 
-	ufd = ul_create_userdata(L, sizeof(*ufd), ufd_m, ul_ufd_delete);
+	ufd = lua_newuserdata(L, sizeof(struct lua_uloop_fd));
+	luaL_setmetatable(L, FD_METANAME);
+
+	memset(ufd, 0, sizeof(struct lua_uloop_fd));
 	ufd->r = ref;
 	ufd->fd.fd = fd;
-	ufd->fd_r = fd_ref;
 	ufd->fd.cb = ul_ufd_cb;
-	if (flags)
-		uloop_fd_add(&ufd->fd, flags);
+
+	uloop_fd_add(&ufd->fd, flags);
 
 	return 1;
 }
 
-static int ul_process_free(lua_State *L)
+static int ul_process_delete(lua_State *L)
 {
-	struct lua_uloop_process *proc = lua_touserdata(L, 1);
+	struct lua_uloop_process *proc = luaL_checkudata(L, 1, PROCESS_METANAME);
 
-	/* obj.__index.__gc = nil , make sure executing only once*/
-	lua_getfield(L, -1, "__index");
-	lua_pushstring(L, "__gc");
-	lua_pushnil(L);
-	lua_settable(L, -3);
+	uloop_process_delete(&proc->p);
 
-	if (proc->r != LUA_NOREF) {
-		uloop_process_delete(&proc->p);
+	return 0;
+}
 
-		lua_getglobal(state, "__uloop_cb");
-		luaL_unref(state, -1, proc->r);
-		lua_remove(state, -1);
-	}
+static int ul_process__gc(lua_State *L)
+{
+	struct lua_uloop_process *proc = luaL_checkudata(L, 1, PROCESS_METANAME);
 
-	return 1;
+	uloop_process_delete(&proc->p);
+	luaL_unref(state, LUA_REGISTRYINDEX, proc->r);
+
+	return 0;
 }
 
 static int ul_process_pid(lua_State *L)
 {
-	struct lua_uloop_process *proc = lua_touserdata(L, 1);
+	struct lua_uloop_process *proc = luaL_checkudata(L, 1, PROCESS_METANAME);
 
 	if (proc->p.pid) {
 		lua_pushnumber(L, proc->p.pid);
@@ -370,8 +371,9 @@ static int ul_process_pid(lua_State *L)
 }
 
 static const luaL_Reg process_m[] = {
-	{ "delete", ul_process_free },
+	{ "delete", ul_process_delete },
 	{ "pid", ul_process_pid },
+	{ "__gc", ul_process__gc },
 	{ NULL, NULL }
 };
 
@@ -379,14 +381,26 @@ static void ul_process_cb(struct uloop_process *p, int ret)
 {
 	struct lua_uloop_process *proc = container_of(p, struct lua_uloop_process, p);
 
-	lua_getglobal(state, "__uloop_cb");
-	lua_rawgeti(state, -1, proc->r);
+	lua_rawgeti(state, LUA_REGISTRYINDEX, proc->r);
 
-	luaL_unref(state, -2, proc->r);
-	proc->r = LUA_NOREF;
-	lua_remove(state, -2);
 	lua_pushinteger(state, ret >> 8);
 	lua_call(state, 1, 0);
+}
+
+/*
+ * Stored with the upvalues:
+ * 2. lua callback
+ * And called with the arguments
+ * 1. ret/signaled status
+ */
+static int ul_process_closure(lua_State *L)
+{
+	lua_pushvalue(L, lua_upvalueindex(1));
+	/* push events */
+	lua_pushvalue(L, 1);
+
+	lua_call(state, 1, 0);
+	return 0;
 }
 
 /***
@@ -403,27 +417,21 @@ static int ul_process(lua_State *L)
 	pid_t pid;
 	int ref;
 
-	if (!lua_isfunction(L, -1) || !lua_istable(L, -2) ||
-			!lua_istable(L, -3) || !lua_isstring(L, -4)) {
-		lua_pushstring(L, "invalid arg list");
-		lua_error(L);
-
-		return 0;
-	}
+	luaL_checktype(L, 1, LUA_TSTRING);
+	luaL_checktype(L, 2, LUA_TTABLE);
+	luaL_checktype(L, 3, LUA_TTABLE);
+	luaL_checktype(L, 4, LUA_TFUNCTION);
 
 	pid = fork();
 
 	if (pid == -1) {
-		lua_pushstring(L, "failed to fork");
-		lua_error(L);
-
-		return 0;
+		return luaL_error(L, "failed to fork");
 	}
 
 	if (pid == 0) {
 		/* child */
-		int argn = lua_rawlen(L, -3);
-		int envn = lua_rawlen(L, -2);
+		int argn = lua_rawlen(L, 2);
+		int envn = lua_rawlen(L, 3);
 		char** argp = malloc(sizeof(char*) * (argn + 2));
 		char** envp = malloc(sizeof(char*) * (envn + 1));
 		int i = 1;
@@ -431,7 +439,7 @@ static int ul_process(lua_State *L)
 		if (!argp || !envp)
 			_exit(-1);
 
-		argp[0] = (char*) lua_tostring(L, -4);
+		argp[0] = (char*) lua_tostring(L, 1);
 		for (i = 1; i <= argn; i++) {
 			lua_rawgeti(L, -3, i);
 			argp[i] = (char*) lua_tostring(L, -1);
@@ -450,11 +458,13 @@ static int ul_process(lua_State *L)
 		_exit(-1);
 	}
 
-	lua_getglobal(L, "__uloop_cb");
-	lua_pushvalue(L, -2);
-	ref = luaL_ref(L, -2);
+	lua_pushcclosure(L, ul_process_closure, 1);
+	ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
-	proc = ul_create_userdata(L, sizeof(*proc), process_m, ul_process_free);
+	proc = lua_newuserdata(L, sizeof(struct lua_uloop_process));
+	luaL_setmetatable(L, PROCESS_METANAME);
+
+	memset(proc, 0, sizeof(struct lua_uloop_process));
 	proc->r = ref;
 	proc->p.pid = pid;
 	proc->p.cb = ul_process_cb;
@@ -473,25 +483,18 @@ static int ul_pid_add(lua_State *L)
 {
 	struct lua_uloop_process *proc;
 	lua_Integer pid;
-	int isint;
 	int ref;
 
-	pid = lua_tointegerx(L, 1, &isint);
-	if (!isint) {
-		lua_pushliteral(L, "First argument should be pid");
-		lua_error(L);
-	}
+	pid = luaL_checkinteger(L, 1);
+	luaL_checktype(L, 2, LUA_TFUNCTION);
 
-	if (!lua_isfunction(L, 2)) {
-		lua_pushliteral(L, "Second argument should be callback function");
-		lua_error(L);
-	}
+	lua_pushcclosure(L, ul_process_closure, 1);
+	ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
-	lua_getglobal(L, "__uloop_cb");
-	lua_pushvalue(L, -2);
-	ref = luaL_ref(L, -2);
+	proc = lua_newuserdata(L, sizeof(struct lua_uloop_process));
+	luaL_setmetatable(L, PROCESS_METANAME);
 
-	proc = ul_create_userdata(L, sizeof(*proc), process_m, ul_process_free);
+	memset(proc, 0, sizeof(struct lua_uloop_process));
 	proc->r = ref;
 	proc->p.pid = pid;
 	proc->p.cb = ul_process_cb;
@@ -537,19 +540,30 @@ static luaL_Reg uloop_func[] = {
 int luaopen_uloop(lua_State *L);
 int luaclose_uloop(lua_State *L);
 
+static void ul_create_metatable(lua_State *L, const luaL_Reg *funcs, const char *name)
+{
+	/* create metatable for the timers */
+	luaL_newmetatable(L, name);
+
+	/* metatable.__index = metatable */
+	lua_pushvalue(L, -1);
+	lua_setfield(L, -2, "__index");
+	/* fill metatable */
+	luaL_setfuncs(L, funcs, 0);
+	lua_pop(L, 1);
+}
+
 int luaopen_uloop(lua_State *L)
 {
 	state = L;
 
-	lua_createtable(L, 1, 0);
-	lua_setglobal(L, "__uloop_cb");
+	ul_create_metatable(L, timer_m, TIMER_METANAME);
+	ul_create_metatable(L, ufd_m, FD_METANAME);
+	ul_create_metatable(L, process_m, PROCESS_METANAME);
 
-	lua_createtable(L, 1, 0);
-	lua_setglobal(L, "__uloop_fds");
-
-    luaL_newlib(L, uloop_func);
+	luaL_newlib(L, uloop_func);
 	lua_pushstring(L, "_VERSION");
-	lua_pushstring(L, "1.0");
+	lua_pushstring(L, "1.3");
 	lua_rawset(L, -3);
 
 	lua_pushstring(L, "ULOOP_READ");


### PR DESCRIPTION
Callbacks didn't create unique references and would result in
deferencing references in use by other callbacks which would then fail.
This moves the library towards more standard Lua, using unique
references based on then global registery instead of series of global
tables.